### PR TITLE
Unify deploy: tag push runs ansible converge in one workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -138,8 +138,13 @@ jobs:
   deploy:
     # Runs after a successful image build on tag pushes, AND on manual workflow_dispatch
     # (which skips `docker` and re-converges the box against whatever image :latest points at).
+    # Explicitly excluded from PR builds and master-branch pushes so we don't deploy on every commit.
     needs: [docker]
-    if: ${{ always() && needs.docker.result != 'failure' && needs.docker.result != 'cancelled' }}
+    if: >-
+      ${{ always()
+          && needs.docker.result != 'failure'
+          && needs.docker.result != 'cancelled'
+          && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -163,7 +168,8 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          source: "playbook.yml,templates/*,hosts.ini,requirements.yml,docker-compose.yml,.env.enc,.sops.yaml"
+          # Pass `templates` as a directory (not `templates/*`) so subpaths are preserved on the remote.
+          source: "playbook.yml,templates,hosts.ini,requirements.yml,docker-compose.yml,.env.enc,.sops.yaml"
           target: "/home/${{ secrets.SERVER_USER }}/api-server-deploy"
           rm: true
 
@@ -173,7 +179,9 @@ jobs:
           AGE_PRIVATE_KEY: ${{ secrets.AGE_PRIVATE_KEY }}
           TLS_KEYSTORE_PASSWORD: ${{ secrets.TLS_KEYSTORE_PASSWORD }}
           GHCR_PAT_RO: ${{ secrets.GHCR_PAT_RO }}
-          GHCR_USER: ${{ github.actor }}
+          # GHCR_USER must match the account that owns GHCR_PAT_RO — use the repo owner (stable)
+          # rather than github.actor (which varies by who triggers workflow_dispatch / tag push).
+          GHCR_USER: ${{ github.repository_owner }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
@@ -182,10 +190,6 @@ jobs:
           script: |
             set -euo pipefail
             cd ~/api-server-deploy
-            # templates/ landed flat (scp-action strips the leading dir) — restore the expected layout.
-            if [ ! -d templates ] && ls api-server.conf.j2 >/dev/null 2>&1; then
-              mkdir -p templates && mv api-server.conf.j2 templates/
-            fi
             ansible-galaxy collection install -r requirements.yml
             umask 077
             SECRETS_FILE="$(mktemp /tmp/ansible-secrets.XXXXXX.yml)"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,7 @@ on:
       - "v*.*.*"
   pull_request:
     branches: ["master"]
+  workflow_dispatch:
 permissions:
   contents: write
   packages: write
@@ -85,6 +86,7 @@ jobs:
     needs: ci-test
     timeout-minutes: 20
     # 🚨 only run if this workflow was triggered by a tag push (release)
+    # workflow_dispatch reruns skip the build and re-converge the box against :latest.
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout files for Docker creation
@@ -134,43 +136,66 @@ jobs:
           cache-to: type=gha,mode=max
 
   deploy:
-    needs: docker
+    # Runs after a successful image build on tag pushes, AND on manual workflow_dispatch
+    # (which skips `docker` and re-converges the box against whatever image :latest points at).
+    needs: [docker]
+    if: ${{ always() && needs.docker.result != 'failure' && needs.docker.result != 'cancelled' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # 🚨 only run if this workflow was triggered by a tag push (release)
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - name: Fetch file to be sent to server
+      - name: Checkout ansible payload
         uses: actions/checkout@v6
         with:
+          # Keep this list in sync with what the playbook reads on the server.
           sparse-checkout: |
+            playbook.yml
+            templates
+            hosts.ini
+            requirements.yml
             docker-compose.yml
+            .env.enc
+            .sops.yaml
           sparse-checkout-cone-mode: false
 
-      - name: Set up SCP
-        run: |
-          mkdir -v -m 700 $HOME/.ssh
-          ssh-keyscan -H ${{ secrets.SERVER_HOST }} > $HOME/.ssh/known_hosts
-          echo "${{ secrets.SERVER_SSH_KEY }}" > $HOME/.ssh/id_rsa
-          chmod 400 $HOME/.ssh/id_rsa
+      - name: Ship ansible payload to server
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: "playbook.yml,templates/*,hosts.ini,requirements.yml,docker-compose.yml,.env.enc,.sops.yaml"
+          target: "/home/${{ secrets.SERVER_USER }}/api-server-deploy"
+          rm: true
 
-      - name: Upload to server
-        run: |
-          scp -o StrictHostKeyChecking=no docker-compose.yml ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/tmp/
-
-      - name: Deploy via SSH
+      - name: Run ansible + docker compose on server
         uses: appleboy/ssh-action@v1.2.5
         env:
+          AGE_PRIVATE_KEY: ${{ secrets.AGE_PRIVATE_KEY }}
+          TLS_KEYSTORE_PASSWORD: ${{ secrets.TLS_KEYSTORE_PASSWORD }}
           GHCR_PAT_RO: ${{ secrets.GHCR_PAT_RO }}
           GHCR_USER: ${{ github.actor }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          envs: GHCR_PAT_RO,GHCR_USER
+          envs: AGE_PRIVATE_KEY,TLS_KEYSTORE_PASSWORD,GHCR_PAT_RO,GHCR_USER
           script: |
-            echo "${GHCR_PAT_RO}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
-            cd /tmp
-            docker compose pull
-            docker compose up -d
-            docker image prune -f
+            set -euo pipefail
+            cd ~/api-server-deploy
+            # templates/ landed flat (scp-action strips the leading dir) — restore the expected layout.
+            if [ ! -d templates ] && ls api-server.conf.j2 >/dev/null 2>&1; then
+              mkdir -p templates && mv api-server.conf.j2 templates/
+            fi
+            ansible-galaxy collection install -r requirements.yml
+            umask 077
+            SECRETS_FILE="$(mktemp /tmp/ansible-secrets.XXXXXX.yml)"
+            trap 'shred -u "$SECRETS_FILE" 2>/dev/null || rm -f "$SECRETS_FILE"' EXIT
+            {
+              printf 'age_private_key: |\n'
+              printf '%s\n' "$AGE_PRIVATE_KEY" | sed 's/^/  /'
+              printf 'tls_keystore_password: "%s"\n' "${TLS_KEYSTORE_PASSWORD//\"/\\\"}"
+              printf 'ghcr_user: "%s"\n' "${GHCR_USER//\"/\\\"}"
+              printf 'ghcr_pat_ro: "%s"\n' "${GHCR_PAT_RO//\"/\\\"}"
+              printf 'docker_deploy: true\n'
+            } > "$SECRETS_FILE"
+            ansible-playbook -i hosts.ini -l local playbook.yml -e "@$SECRETS_FILE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ mvn -P ci -Dtest=com.chencraft.common.service.HashServiceTest#testValidateHash t
 
 ## Deployment
 
-Docker image built on tag push via GitHub Actions → pushed to GHCR → deployed via SSH + docker-compose. Ansible playbook handles Nginx and server provisioning.
+Tag push (`v*.*.*`) triggers `.github/workflows/maven.yml`: build & test → push image to GHCR → SCP the ansible payload (`playbook.yml`, `templates/`, `docker-compose.yml`, `.env.enc`, etc.) to the server → SSH as `githubdeploy` and run `ansible-playbook` unattended. The playbook converges nginx + PKCS#12 + deploy user, then (when `docker_deploy=true` is passed from CI) runs `docker compose pull && up -d` against `/opt/api-server/docker-compose.yml`. Manual `workflow_dispatch` re-runs the deploy job without rebuilding the image (useful for nginx-only changes). Laptop bootstrap is still `./install.sh`.
 
 ## Skill maintenance — `api-chencraft`
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ API docs (local): https://dev.chencraft.com/
 
 ## Provisioning and Nginx setup (Ansible)
 
-The legacy Bash scripts (install.sh and install-dev.sh) have been replaced by an Ansible playbook.
+Server provisioning + per-release deploys both run the same Ansible playbook (`playbook.yml`).
+Tag pushes trigger the playbook automatically from GitHub Actions; `./install.sh` is the
+laptop-side entry point for first-time bootstrap and ad-hoc local runs.
 
 Prerequisites:
 
-- Ansible installed on your machine
+- Ansible installed on your machine (and on the target host — see "First-time bootstrap" below)
 - sudo privileges on the target host (for managing nginx and system paths)
 
 Install Ansible Galaxy collections (first time):
@@ -97,17 +99,20 @@ Alternatively, you can invoke Ansible directly and pass extra vars:
 
 What this playbook does:
 
-- Optionally creates a deploy user githubdeploy and installs a provided GitHub Actions public key (skipped in dev mode)
+- Optionally creates a deploy user githubdeploy, installs a provided GitHub Actions public key,
+  and grants it passwordless sudo so CI can re-run the playbook unattended (all skipped in dev mode)
 - Ensures working directory at /opt/api-server with correct owner/permissions
 - Templates and enables an Nginx site for api-server (HTTP 80 redirect to HTTPS 443)
 - Sets upstream proxy port to 8080 (prod) or 8085 (dev)
 - Generates a PKCS#12 keystore at /opt/api-server/server.p12 from existing system cert/key
 - Optionally stores an age private key in /opt/api-server/age_key (0600) if provided
+- When `-e docker_deploy=true ghcr_user=… ghcr_pat_ro=…` is supplied (CI path), also copies
+  docker-compose.yml to /opt/api-server, logs in to GHCR, and runs `docker compose pull && up -d`
 
 Prompts during execution:
 
-- TLS keystore password (used to protect server.p12)
-- Optional: AGE private key (single line) to write to /opt/api-server/age_key
+- TLS keystore password (used to protect server.p12) — skipped when `-e tls_keystore_password=…` is given
+- Optional: AGE private key (single line) to write to /opt/api-server/age_key — skipped when `-e age_private_key=…` is given
 - Optional (non-dev): GitHub Actions public SSH key for the githubdeploy user
 
 Variables you can override with -e:
@@ -117,6 +122,32 @@ Variables you can override with -e:
 - p12_cert_path, p12_key_path: certificate/key used for PKCS#12 export
 - server_host: defaults to api.chencraft.com (prod) or dev.chencraft.com (dev)
 - proxy_port: defaults to 8080 (prod) or 8085 (dev)
+- docker_deploy, ghcr_user, ghcr_pat_ro: CI-only; gate the container deploy task block
 
 CI note: ansible-lint runs in GitHub Actions to validate playbook structure. Ensure requirements.yml is kept in sync
 with modules used.
+
+### First-time bootstrap (one-time)
+
+On a fresh host, run this once (SSH in as a user with sudo, e.g. `ubuntu`):
+
+1. `sudo apt-get update && sudo apt-get install -y ansible-core git`
+2. `git clone <repo> ~/api-server && cd ~/api-server`
+3. `./install.sh` — installs collections, creates `githubdeploy` with passwordless sudo and the
+   GitHub Actions public key, templates nginx, generates the PKCS#12 keystore, places `/opt/api-server/age_key`.
+
+After bootstrap, the GitHub Actions workflow handles every release automatically: it SCPs the
+playbook payload to `~/api-server-deploy/` on the host and runs `ansible-playbook` as `githubdeploy`.
+
+### Required GitHub Actions secrets
+
+- `SERVER_HOST`, `SERVER_USER` (= `githubdeploy`), `SERVER_SSH_KEY` — SSH transport
+- `GHCR_PAT_RO` — read-only PAT for `docker login ghcr.io`
+- `AGE_PRIVATE_KEY` — multi-line; lets ansible decrypt `.env.enc` to extract the proxy secret
+- `TLS_KEYSTORE_PASSWORD` — protects the generated `server.p12`
+
+### Manual re-deploy (no code change)
+
+Use the **Run workflow** button on the `Java CI with Maven` action in GitHub. With no new tag,
+the `docker` job is skipped and `deploy` re-runs the playbook against the current `:latest` image —
+useful for nginx config tweaks, cert rotations, or recovering from a bad manual edit on the host.

--- a/README.md
+++ b/README.md
@@ -151,3 +151,81 @@ playbook payload to `~/api-server-deploy/` on the host and runs `ansible-playboo
 Use the **Run workflow** button on the `Java CI with Maven` action in GitHub. With no new tag,
 the `docker` job is skipped and `deploy` re-runs the playbook against the current `:latest` image —
 useful for nginx config tweaks, cert rotations, or recovering from a bad manual edit on the host.
+
+## Release protocol
+
+### Versioning
+
+Tags follow strict semver `vMAJOR.MINOR.PATCH` (e.g. `v0.4.7`). The trigger pattern in
+`.github/workflows/maven.yml` is `v*.*.*`, so a tag without three dotted numbers is ignored.
+
+At build time the workflow strips the leading `v` and runs `mvn versions:set` so the Maven
+artifact version matches the tag. The Docker image is then pushed to GHCR under **two** tags:
+
+- `ghcr.io/sibeic/api-server:<version>` — immutable, for rollback / pinning
+- `ghcr.io/sibeic/api-server:latest` — moving pointer to the most recent release
+
+`docker-compose.yml` references `:latest`, so `docker compose pull && up -d` always deploys
+the newest release. Roll back by editing the compose file on the host to pin a previous
+`:<version>` tag and re-running the playbook (see "Manual re-deploy" above).
+
+### Cutting a release
+
+```bash
+# 1. Make sure local tags match origin so you don't bump on top of an existing one
+git fetch --tags origin --prune --prune-tags
+
+# 2. Confirm the highest existing tag, then pick the next bump
+git tag --list 'v*' --sort=-v:refname | head -5
+
+# 3. Tag the merge commit on master (annotated, signed if you sign tags)
+git tag -a v0.4.8 -m "Release v0.4.8"
+git push origin v0.4.8
+
+# 4. Create the matching GitHub release immediately — every tag MUST have one
+gh release create v0.4.8 --generate-notes
+```
+
+The tag push triggers `Java CI with Maven`:
+
+| Job       | Runs when                            | What it does                                              |
+| --------- | ------------------------------------ | --------------------------------------------------------- |
+| `ci-test` | every push / PR / dispatch           | Maven build + tests, uploads JAR artifact on tag          |
+| `docker`  | tag push only                        | Builds image from the JAR artifact, pushes to GHCR        |
+| `deploy`  | tag push **or** `workflow_dispatch`  | SCPs the ansible payload → SSH → `ansible-playbook` runs |
+
+`deploy` SSHes in as `githubdeploy`, runs the playbook with `-e docker_deploy=true`, which
+re-converges nginx + PKCS#12 + sudoers + deploy user, then runs `docker compose pull && up -d`
+against `/opt/api-server/docker-compose.yml`. End state: the host is converged to whatever
+the freshly-pushed `:latest` image and the playbook on `master` describe.
+
+### Watching the release
+
+```bash
+# Watch the run after pushing the tag (replace v0.4.8 with your tag)
+gh run watch "$(gh run list --workflow 'Java CI with Maven' --branch v0.4.8 --limit 1 --json databaseId -q '.[0].databaseId')"
+
+# Verify the app is up
+curl -sk https://api.chencraft.com/actuator/health
+```
+
+### Rollback
+
+A bad release can be reverted three ways, in order of preference:
+
+1. **Cut a forward fix** — `git revert <bad-commit> && git tag v0.4.9 && git push --tags`.
+   Cleanest history.
+2. **Pin the compose file to a previous tag** on the host:
+   `ssh githubdeploy@api.chencraft.com 'sed -i "s|:latest|:0.4.7|" /opt/api-server/docker-compose.yml && cd /opt/api-server && docker compose up -d'`.
+   Use as a stop-gap, then cut a forward fix to bring `:latest` back into alignment.
+3. **Re-deploy a known-good tag via workflow_dispatch** — only works if `:latest` in GHCR
+   still points at the good build (i.e. the broken release never finished pushing).
+
+### Tag hygiene
+
+- **Never** retag (`git tag -f v0.4.8 …`). It corrupts the immutable `:<version>` image
+  contract — collaborators and the running host can have different bytes for the same name.
+- **Always** create the matching `gh release` (`--generate-notes` is fine) so the tag shows
+  up in the Releases UI and dependency scanners can attribute CVEs to versions.
+- If you forgot to fetch tags before bumping and collided with a remote tag, delete the
+  local tag (`git tag -d v0.4.8`), fetch again, pick the next number, and re-push.

--- a/playbook.yml
+++ b/playbook.yml
@@ -97,6 +97,12 @@
             state: present
 
         - name: Grant passwordless sudo to deploy user (required for CI-driven playbook runs)
+          # Trust model: githubdeploy is already in the `docker` group, which is effectively root
+          # (a docker-group member can `docker run --privileged -v /:/host alpine chroot /host`).
+          # So NOPASSWD: ALL widens nothing material — it just lets ansible's `become: true` work
+          # over the existing SSH key without an interactive password. Anyone with SERVER_SSH_KEY
+          # already has root-equivalent access via docker. If that trust model ever tightens
+          # (githubdeploy removed from docker group), revisit and narrow this to a Cmnd_Alias.
           ansible.builtin.copy:
             dest: "/etc/sudoers.d/{{ deploy_user }}"
             content: "{{ deploy_user }} ALL=(ALL) NOPASSWD: ALL\n"
@@ -303,14 +309,21 @@
           args:
             chdir: "{{ working_dir }}"
           register: compose_pull
-          changed_when: "'Pulled' in compose_pull.stderr or 'Pulled' in compose_pull.stdout"
+          # Compose v2 may print "Pulled" / "Pulling" on either stream depending on version.
+          changed_when: >-
+            'Pulled' in (compose_pull.stdout | default('')) or
+            'Pulled' in (compose_pull.stderr | default(''))
 
         - name: Bring up containers
           ansible.builtin.command: "docker compose up -d"
           args:
             chdir: "{{ working_dir }}"
           register: compose_up
-          changed_when: "'Started' in compose_up.stderr or 'Recreated' in compose_up.stderr or 'Created' in compose_up.stderr"
+          # Compose v2 reports container lifecycle ("Started" / "Recreated" / "Created")
+          # on either stdout or stderr — check both so the play recap reflects reality.
+          changed_when: >-
+            (compose_up.stdout | default('')) is search('(Started|Recreated|Created)\b') or
+            (compose_up.stderr | default('')) is search('(Started|Recreated|Created)\b')
 
         - name: Prune dangling images
           ansible.builtin.command: "docker image prune -f"

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,6 +36,15 @@
     # and ignored when it isn't (permissive mode).
     proxy_secret: ""
 
+    # Empty default lets CI pass -e tls_keystore_password=... directly (skips sops decrypt path).
+    # When unset, PKCS#12 task self-skips via its own `when:` guard.
+    tls_keystore_password: ""
+
+    # Gate for the container-deploy task block (set true from CI; laptop runs leave false).
+    docker_deploy: false
+    ghcr_user: ""
+    ghcr_pat_ro: ""
+
     # OS-specific defaults
     # - On macOS: default group is 'staff' and work owned by app user/group
     # - On Linux: default user/group root; working_dir owned by root:root per requirements
@@ -86,6 +95,15 @@
             user: "{{ deploy_user }}"
             key: "{{ deploy_user_public_key }}"
             state: present
+
+        - name: Grant passwordless sudo to deploy user (required for CI-driven playbook runs)
+          ansible.builtin.copy:
+            dest: "/etc/sudoers.d/{{ deploy_user }}"
+            content: "{{ deploy_user }} ALL=(ALL) NOPASSWD: ALL\n"
+            owner: root
+            group: root
+            mode: "0440"
+            validate: "visudo -cf %s"
 
     - name: Ensure SSH (22/tcp) open for remote access (non-dev only)
       when: not dev
@@ -259,6 +277,44 @@
       when:
         - tls_keystore_password is defined
         - tls_keystore_password | length > 0
+
+    - name: Deploy container (CI-only; laptop runs leave docker_deploy=false)
+      when: docker_deploy | bool
+      tags: ["deploy"]
+      block:
+        - name: Copy docker-compose.yml to working directory
+          ansible.builtin.copy:
+            src: "docker-compose.yml"
+            dest: "{{ working_dir }}/docker-compose.yml"
+            owner: "{{ app_user }}"
+            group: "{{ app_group }}"
+            mode: "0644"
+
+        - name: Log in to GHCR
+          ansible.builtin.command: "docker login ghcr.io -u {{ ghcr_user }} --password-stdin"
+          args:
+            stdin: "{{ ghcr_pat_ro }}"
+          register: ghcr_login
+          changed_when: false
+          no_log: true
+
+        - name: Pull latest image
+          ansible.builtin.command: "docker compose pull"
+          args:
+            chdir: "{{ working_dir }}"
+          register: compose_pull
+          changed_when: "'Pulled' in compose_pull.stderr or 'Pulled' in compose_pull.stdout"
+
+        - name: Bring up containers
+          ansible.builtin.command: "docker compose up -d"
+          args:
+            chdir: "{{ working_dir }}"
+          register: compose_up
+          changed_when: "'Started' in compose_up.stderr or 'Recreated' in compose_up.stderr or 'Created' in compose_up.stderr"
+
+        - name: Prune dangling images
+          ansible.builtin.command: "docker image prune -f"
+          changed_when: false
 
     - name: Uninstall api-server resources
       tags: ["never", "uninstall"]


### PR DESCRIPTION
## Summary

- Tag pushes (and manual `workflow_dispatch`) now SCP the ansible payload to the server and run `ansible-playbook` unattended — no more pairing `git tag … && git push` with `./install.sh` from a laptop.
- The existing `docker login` + `docker compose pull && up -d` is folded into a CI-gated `Deploy container` task block in `playbook.yml`, so the playbook is the single source of truth for "what should be running on the host."
- `playbook.yml` gains `tls_keystore_password` / `docker_deploy` / `ghcr_user` / `ghcr_pat_ro` vars (CI sets them via `-e @secrets.yml`), plus a sudoers entry for `githubdeploy` so CI-driven `become: true` tasks work. Laptop `./install.sh` is untouched because `docker_deploy` defaults `false` and the new vars are no-ops without `-e`.

## Operator action required before merging

Add two new repo secrets — both already exist on the host:

- `AGE_PRIVATE_KEY` — multi-line contents of `/opt/api-server/age_key`
- `TLS_KEYSTORE_PASSWORD` — the `app.tls.keystore-password` value from the decrypted `.env`

Existing `SERVER_HOST` / `SERVER_USER` (= `githubdeploy`) / `SERVER_SSH_KEY` / `GHCR_PAT_RO` are reused as-is.

One-time bootstrap step on the host (so CI's `ansible-playbook` invocation has what it needs):

```
sudo apt-get install -y ansible-core
cd ~/api-server && ./install.sh   # installs the new githubdeploy sudoers entry
```

## Test plan

- [ ] Add `AGE_PRIVATE_KEY` and `TLS_KEYSTORE_PASSWORD` GitHub secrets
- [ ] SSH to the host once and run `./install.sh` to install the new sudoers entry + ensure `ansible-core` is present
- [ ] Trigger the workflow via **Run workflow** (workflow_dispatch) — `docker` job should be skipped, `deploy` should SCP files and run the playbook against `:latest`
- [ ] Verify on host: `ls -la /opt/api-server` shows `docker-compose.yml`, `server.p12`, `age_key`; `curl -sk https://api.chencraft.com/actuator/health` returns `{"status":"UP"}`
- [ ] Cut a real release tag (e.g. `v0.x.y`) and confirm `ci-test → docker → deploy` runs end-to-end
- [ ] Confirm `./install.sh` from laptop still reports 0 changes (idempotent — interactive path not broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)