### PR TITLE
Bump Qodana linter from 2025.3 to 2026.1

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,6 @@
 ---
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2025.3
+linter: jetbrains/qodana-jvm-community:2026.1
 projectJDK: "25"
 profile:
   name: qodana.recommended


### PR DESCRIPTION
Aligns the `qodana.yaml` linter with the `qodana-action@v2026.1` CLI, which currently warns:

> You are using a non-compatible Qodana linter jetbrains/qodana-jvm-community:2025.3 with the current CLI (2026.1.0). Consider updating CLI or using a compatible linter jetbrains/qodana-jvm-community:2026.1

This mismatch is the suspected cause of the recurring Qodana failures on master pushes (2026-06-04 run 26931814015 and 2026-06-11 run 27328515558): both show 20 Critical "Java sanity" unresolved-symbol errors followed by 54 identical bogus findings ("Field may be 'final'" ×35, "Field can be local variable" ×16) on ordinary Lombok `@Data`/`@Getter` classes — classic annotation-processing misfire. The same source passes cleanly when the sanity check succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)