### PR TITLE
Warm Maven repository before Qodana scan

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -25,6 +25,23 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }} # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0 # a full history is required for pull request analysis
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+      - name: Cache Qodana Maven repository
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/qodana/caches/.m2
+          key: ${{ runner.os }}-qodana-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-qodana-m2-
+      # Qodana's own Maven import intermittently skips downloading dependencies,
+      # leaving unresolved library roots that break the sanity check and produce
+      # bogus findings. Seed the repo it uses (/data/cache/.m2) ourselves.
+      - name: Warm Maven repository for Qodana
+        run: mvn -B -P ci -DskipTests dependency:go-offline -Dmaven.repo.local=${{ runner.temp }}/qodana/caches/.m2
       - name: "Qodana Scan"
         uses: JetBrains/qodana-action@v2026.1
         with:

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -46,7 +46,10 @@ jobs:
         uses: JetBrains/qodana-action@v2026.1
         with:
           pr-mode: true
-          cache-default-branch-only: true
+          # built-in caching never restored (per-SHA keys) and would now
+          # re-upload the pre-seeded .m2 every run; the explicit
+          # actions/cache step above manages the Maven repo instead
+          use-caches: false
           args: --fail-threshold,0
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_2097965348 }}


### PR DESCRIPTION
The linter bump in #138 did not fix the recurring master Qodana failures — runs 27328515558 and 27331194671 (and their reruns) all failed with the same signature, as did 26931814015 on 2026-06-04.

**Root cause:** Qodana's own Maven import intermittently completes without downloading dependencies. Failing runs finish the *project opening* stage in 26–37s vs **11m 33s** in passing runs, and log `Roots jar:///data/cache/.m2/... were not resolved` for every library. With an unresolved classpath the sanity check fails on a rotating set of files (20 Critical "Java sanity" problems) and annotation processing misfires, producing 54 bogus findings ("Field may be 'final'" ×35, "Field can be local variable" ×16, …) that trip `--fail-threshold 0`.

**Fix:** seed the exact Maven repo path the Qodana container uses (`<cache-dir>/.m2` → `/data/cache/.m2`) with `mvn dependency:go-offline` before the scan, cached on `pom.xml` hash, so the analysis never depends on Qodana's flaky download step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)