### PR TITLE
Clarify doppler --fallback semantics in entrypoint comment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,7 @@
 set -eu
 
 # Inject secrets from Doppler (project/config implied by DOPPLER_TOKEN service token).
-# --fallback keeps restarts working if api.doppler.com is briefly unreachable.
+# --fallback keeps restarts working if api.doppler.com is briefly unreachable: doppler
+# itself writes/refreshes this encrypted file on every successful fetch (it need not
+# pre-exist) and only reads it when the API is unreachable.
 exec doppler run --fallback /opt/api-server/doppler-fallback.json -- java -jar api-server.jar


### PR DESCRIPTION
Follow-up to #141, addressing the Copilot review comment on `entrypoint.sh`: verified with doppler CLI v3.76.0 that `doppler run --fallback <path>` auto-creates/refreshes the encrypted fallback file on each successful fetch — it need not pre-exist and is only read when api.doppler.com is unreachable. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)