### PR TITLE
Restart app on Doppler config changes via doppler run --watch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,9 @@ set -eu
 # --fallback keeps restarts working if api.doppler.com is briefly unreachable: doppler
 # itself writes/refreshes this encrypted file on every successful fetch (it need not
 # pre-exist) and only reads it when the API is unreachable.
-exec doppler run --fallback /opt/api-server/doppler-fallback.json -- java -jar api-server.jar
+# --watch (BETA) restarts the JVM in place whenever the Doppler config changes, so
+# app-only secrets rotate without touching the box. Batch multi-secret rotations into
+# one `doppler secrets set K1=… K2=…` call (each change event = one restart), and
+# rotate nginx/p12-coupled secrets (proxy secret, keystore password) via an ansible
+# re-converge instead — a watch restart alone would leave nginx/p12 out of sync.
+exec doppler run --watch --fallback /opt/api-server/doppler-fallback.json -- java -jar api-server.jar


### PR DESCRIPTION
Adds `--watch` (BETA) to `doppler run` in the entrypoint: the CLI holds a connection to Doppler and restarts the JVM in place whenever the `prd` config changes, so app-only secrets (Mongo URI, R2 keys, GitHub tokens, mail creds) rotate with nothing but a Doppler update — same brief 502 window as a deploy.

Caveats documented in the entrypoint comment:
- batch multi-secret rotations into a single `doppler secrets set K1=… K2=…` call (each change event triggers one restart)
- nginx/p12-coupled secrets (`APP_MTLS_PROXY_SECRET`, `APP_TLS_KEYSTORE_PASSWORD`) must still go through an ansible re-converge — a watch restart alone would leave nginx/the keystore out of sync

Verified locally that `--watch --fallback` combine cleanly and the wrapped process runs and exits normally (doppler CLI v3.76.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)