### PR TITLE
Scope Java CI token permissions to least privilege

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,11 +9,9 @@ on:
   pull_request:
     branches: ["master"]
   workflow_dispatch:
+# Least privilege by default; jobs opt into more only where they need it.
 permissions:
-  contents: write
-  packages: write
-  id-token: write
-  security-events: write
+  contents: read
 
 jobs:
   ci-test:
@@ -81,6 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci-test
     timeout-minutes: 20
+    # Only this job touches GHCR (login + image push), so it is the only one granted packages:write.
+    permissions:
+      contents: read
+      packages: write
     # 🚨 only run if this workflow was triggered by a tag push (release)
     # workflow_dispatch reruns skip the build and re-converge the box against :latest.
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Follow-up to 2f38800, which removed the redundant `Update dependency graph` step.

## Why

`maven.yml` granted four write scopes to every job:

```yaml
permissions:
  contents: write
  packages: write
  id-token: write
  security-events: write
```

Auditing what the workflow actually does:

- **`id-token: write`** — nothing uses OIDC (no cloud login, no keyless signing). The `cache-to: type=gha` in `build-push-action` uses the Actions runtime token, not OIDC.
- **`security-events: write`** — nothing uploads SARIF here. Code scanning lives in the separate CodeQL and Qodana workflows, which carry their own permissions.
- **`contents: write`** — was only needed by the dependency-graph submission step removed in 2f38800. Nothing left creates a release, or pushes a commit or tag. (`Extract version` runs `mvn versions:set` locally and never pushes.)
- **`packages: write`** — genuinely needed, but only by `docker`, for the GHCR login and image push.

## Change

Default to `contents: read`, and let `docker` opt into the `packages: write` it needs.

| job | effective permissions |
|---|---|
| `ci-test` | `contents: read` (inherited) |
| `docker` | `contents: read`, `packages: write` (job-level) |
| `deploy` | `contents: read` (inherited) |

The `docker` job's GHCR-relevant grant is unchanged — it had `packages: write` from the top-level block before and has it explicitly now.

## Verification

- `actionlint` is clean (same 4 pre-existing shellcheck info notes as before this change).
- Effective per-job permissions confirmed by parsing the resolved YAML.
- Pre-push hook: 69 tests, 0 failures.

⚠️ **Coverage limit:** only `ci-test` runs on a PR — `docker` and `deploy` are gated on `refs/tags/`. So a green check here validates `ci-test` under `contents: read`, but the `docker` job's `packages: write` is not exercised until the next release tag. Each job only reads repo contents via `actions/checkout`, so the reduction to `contents: read` is safe by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJNZN4SSHVBz3oHYox8x1p
